### PR TITLE
Hotfix onprem

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: apde.etl
 Title: APDE Tools for ETL (Extract, Transform, & Load) Procesess
-Version: 1.01
+Version: 1.02
 Authors@R: 
     person("Danny", "Colombara", , "dcolombara@kingcounty.gov", role = c("aut", "cre"))
 Description: Provides tools for ETL and informatics processes.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: apde.etl
 Title: APDE Tools for ETL (Extract, Transform, & Load) Procesess
-Version: 1.01
+Version: 1.01.1
 Authors@R: 
     person("Danny", "Colombara", , "dcolombara@kingcounty.gov", role = c("aut", "cre"))
 Description: Provides tools for ETL and informatics processes.

--- a/R/create_db_connection.R
+++ b/R/create_db_connection.R
@@ -72,12 +72,20 @@ create_db_connection <- function(server = c("phextractstore", "hhsaw", "inthealt
       conn <- DBI::dbConnect(odbc::odbc(),
                               Driver = getOption('apde.etl.odbc_version'),
                               Server = "KCITSQLPRPHIP40",
-                              Database = "PHExtractStore")
+                              Database = "PHExtractStore",
+                              Encrypt = "yes",
+                              Authentication = "ActiveDirectoryIntegrated",
+                              TrustServerCertificate = 'yes' #Not ideal, but probably fine since its on prem
+                             )
     } else {
       conn <- DBI::dbConnect(odbc::odbc(),
                               Driver = getOption('apde.etl.odbc_version'),
                               Server = "KCITSQLUATHIP40",
-                              Database = "PHExtractStore")
+                              Database = "PHExtractStore",
+                              Encrypt = "yes",
+                              Authentication = "ActiveDirectoryIntegrated",
+                              TrustServerCertificate = 'yes' #Not ideal, but probably fine since its on prem
+                             )
     }
   } else if (interactive == F) {
     conn <- DBI::dbConnect(odbc::odbc(),

--- a/R/create_db_connection.R
+++ b/R/create_db_connection.R
@@ -70,14 +70,20 @@ create_db_connection <- function(server = c("phextractstore", "hhsaw", "inthealt
   if (server == "phextractstore") {
     if (prod == T) {
       conn <- DBI::dbConnect(odbc::odbc(),
-                              Driver = getOption('apde.etl.odbc_version'),
-                              Server = "KCITSQLPRPHIP40",
-                              Database = "PHExtractStore")
+                             Driver = "SQL Server",
+                             Server = "KCITSQLPRPHIP40",
+                             Database = "PHExtractStore",
+                             Trusted_Connection = "yes",
+                             TrustServerCertificate = "yes",
+                             Encrypt = "no")
     } else {
       conn <- DBI::dbConnect(odbc::odbc(),
-                              Driver = getOption('apde.etl.odbc_version'),
-                              Server = "KCITSQLUATHIP40",
-                              Database = "PHExtractStore")
+                             Driver = "SQL Server",
+                             Server = "KCITSQLUATHIP40",
+                             Database = "PHExtractStore",
+                             Trusted_Connection = "yes",
+                             TrustServerCertificate = "yes",
+                             Encrypt = "no")
     }
   } else if (interactive == F) {
     conn <- DBI::dbConnect(odbc::odbc(),

--- a/R/create_db_connection.R
+++ b/R/create_db_connection.R
@@ -70,7 +70,7 @@ create_db_connection <- function(server = c("phextractstore", "hhsaw", "inthealt
   if (server == "phextractstore") {
     if (prod == T) {
       conn <- DBI::dbConnect(odbc::odbc(),
-                             Driver = "SQL Server",
+                             Driver = getOption('apde.etl.odbc_version'),
                              Server = "KCITSQLPRPHIP40",
                              Database = "PHExtractStore",
                              Trusted_Connection = "yes",
@@ -78,7 +78,7 @@ create_db_connection <- function(server = c("phextractstore", "hhsaw", "inthealt
                              Encrypt = "no")
     } else {
       conn <- DBI::dbConnect(odbc::odbc(),
-                             Driver = "SQL Server",
+                             Driver = getOption('apde.etl.odbc_version'),
                              Server = "KCITSQLUATHIP40",
                              Database = "PHExtractStore",
                              Trusted_Connection = "yes",


### PR DESCRIPTION
 - previously errored after updating to use `getOption('apde.etl.odbc_version')`
 - passed all tests (including manual tests) 
    0 errors ✔ | 0 warnings ✔ | 1 note ✖