### PR TITLE
Fix etl_qa_run_pipeline

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 ^LICENSE\.md$
 ^tests/manual$
 ^quarto_docs$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .Rproj.user
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: apde.etl
 Title: APDE Tools for ETL (Extract, Transform, & Load) Procesess
-Version: 1.01.2
+Version: 1.01.3
 Authors@R: 
     person("Danny", "Colombara", , "dcolombara@kingcounty.gov", role = c("aut", "cre"))
 Description: Provides tools for ETL and informatics processes.

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -21,7 +21,7 @@
 #' - `check_chi`: Logical vector of length 1. When `check_chi = TRUE`,
 #'   function will add any available CHI related variables to `cols` and
 #'   will assess whether their values align with standards in
-#'   `rads.data::misc_chi_byvars`. Default is `FALSE`
+#'   `apde.chi.tools::chi_standard_varnames`. Default is `FALSE`
 #'
 #' - `cols`: Character vector specifying the column names to analyze,
 #'   e.g., `cols = c('race4', 'birth_weight_grams', 'birthplace_city')`
@@ -584,7 +584,7 @@ etl_qa_setup_config <- function(data_source_type,
 #' - `vals_categorical`: A frequency table of the top 8 most frequent values
 #'         of categorical variable (and numerics or dates with < your specified `distinct_threshold` distinct values) PLUS a rows for `NA`
 #'         PLUS a row for all 'Other values'
-#' - `chi_standards`: Comparison of CHI (Community Health Indicator) variables values with those expected based on `rads.data::misc_chi_byvars`
+#' - `chi_standards`: Comparison of CHI (Community Health Indicator) variables values with those expected based on `apde.chi.tools::chi_standard_varnames`
 #'
 #' @examples
 #' \dontrun{
@@ -670,7 +670,7 @@ process_r_dataframe <- function(config) {
     }
 
     if(isTRUE(config$data_params$check_chi)){
-      byvars <- unique(rads.data::misc_chi_byvars$varname)
+      byvars <- unique(apde.chi.tools::chi_standard_varnames$varname)
       chivars <- c(grep('^chi_', possiblecols, value = TRUE))
     } else {byvars <- NULL; chivars <- NULL}
 
@@ -757,7 +757,7 @@ process_r_dataframe <- function(config) {
   # Comparison with CHI standards (if needed) ----
   if(isTRUE(config$data_params$check_chi)){
     # Get all gold standard CHI varnames and groups
-    chi_std <- unique(rads.data::misc_chi_byvars[, list(varname, group, chi = 1L)])
+    chi_std <- unique(apde.chi.tools::chi_standard_varnames[, list(varname, group, chi = 1L)])
 
     # Identify all categorical chi variables that are in the data.frame/data.table
     categorical_cols <- setdiff(names(dt), c(config$time_var, numeric_cols, date_cols))
@@ -830,7 +830,7 @@ process_rads_data <- function(config) {
   }
 
   if(isTRUE(config$data_params$check_chi)){
-    byvars <- unique(rads.data::misc_chi_byvars$varname)
+    byvars <- unique(apde.chi.tools::chi_standard_varnames$varname)
     chivars <- c(grep('^chi_', possiblecols, value = TRUE))
   } else {byvars <- NULL; chivars <- NULL}
 
@@ -882,7 +882,7 @@ process_sql_server <- function(config) {
   }
 
   if(isTRUE(config$data_params$check_chi)){
-    byvars <- unique(rads.data::misc_chi_byvars$varname)
+    byvars <- unique(apde.chi.tools::chi_standard_varnames$varname)
     chivars <- c(grep('^chi_', possiblecols, value = TRUE))
   } else {byvars <- NULL; chivars <- NULL}
 
@@ -943,7 +943,7 @@ process_sql_server <- function(config) {
     # Get all gold standard CHI varnames and groups
     # use unique(...) because some varname group combos duplicated because birth
     # data has different `cat` than other data
-    chi_std <- unique(rads.data::misc_chi_byvars[, list(varname, group, chi = 1L)])
+    chi_std <- unique(apde.chi.tools::chi_standard_varnames[, list(varname, group, chi = 1L)])
 
     # Limit chi_std to categorical variables in frequency table
     chi_std <- chi_std[varname %in% unique(categorical_freq$varname)]
@@ -982,7 +982,7 @@ process_sql_server <- function(config) {
 
 # Helper functions in R code ----
 ## comp_2_chi_std() ----
-#' Compare data to CHI standards in rads.data::misc_chi_byvars
+#' Compare data to CHI standards in apde.chi.tools::chi_standard_varnames
 #'
 #' `used by process_sql_server()` & 'process_r_dataframe()'
 #'
@@ -1004,7 +1004,7 @@ comp_2_chi_std <- function(myCHIcomparison, time_var){
 
   if (nrow(only_chi) > 0){
     message("\U0001f626\U0001f47f\U0001F92C\u26A0\ufe0f \n",
-            "The following varname and group combinations exist in the rads.data::misc_chi_byvars \n",
+            "The following varname and group combinations exist in the apde.chi.tools::chi_standard_varnames \n",
             "standards but are missing from your dataset. Please ensure your dataset complies with\n",
             "the CHI standard.\n\n",
             paste(formatted_table, collapse = "\n"), '\n')
@@ -1019,13 +1019,13 @@ comp_2_chi_std <- function(myCHIcomparison, time_var){
                                    align = c('r', 'l', 'l'))
   if (nrow(only_your_data) > 0){
     message("\U0001f626\U0001f47f\U0001F92C\u26A0\ufe0f \nThe following varname & group combinations in your table are not valid\n",
-            "when compared to rads.data::misc_chi_byvars:\n\n",
+            "when compared to apde.chi.tools::chi_standard_varnames:\n\n",
             paste(formatted_table2, collapse = "\n"), '\n')
   }
 
   # Give message of success if there are no problems ----
   if (nrow(only_your_data) == 0 && nrow(only_chi) == 0){
-    message("\U0001f973\U0001f389\nAll of the CHI variables found in your dataset are formatted according to the standards in rads.data::misc_chi_byvars!\n")
+    message("\U0001f973\U0001f389\nAll of the CHI variables found in your dataset are formatted according to the standards in apde.chi.tools::chi_standard_varnames!\n")
   }
 
 }
@@ -1477,7 +1477,7 @@ generate_categorical_query <- function(config) {
 #' @return A list containing formatted and combined results that consists of:
 #' - `missingness`: Structured summary of the proportion of missing data per variable and time point
 #' - `values`: Combined table with the frequency of categorical variables and simple statistics for numeric and date / datetime variables
-#' - `chi_standards`: Comparison of CHI (Community Health Indicator) variables values with those expected based on `rads.data::misc_chi_byvars`
+#' - `chi_standards`: Comparison of CHI (Community Health Indicator) variables values with those expected based on `apde.chi.tools::chi_standard_varnames`
 #'
 #' @examples
 #' \dontrun{

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -1879,15 +1879,21 @@ plotCONTINUOUS <- function(var_data, time_var, mytitle) {
 #'
 #'
 plotDATE <- function(var_data, time_var, mytitle) {
+  # Drop rows for years without data because some questions asked alternating years
+  var_data <- var_data[!is.na(median_date)]
+
   # Typical case where there is more than 1 row of data
   if (nrow(var_data[!is.na(median_date)]) > 1){
     plot <-   ggplot2::ggplot(var_data[!is.na(median_date)]) +
       ggplot2::geom_line(ggplot2::aes(x = time_period, y = min_date, color = "Minimum", linetype = "Minimum"), linewidth = 2) +
       ggplot2::geom_line(ggplot2::aes(x = time_period, y = median_date, color = "Median", linetype = "Median"), linewidth = 1.5) +
       ggplot2::geom_line(ggplot2::aes(x = time_period, y = max_date, color = "Maximum", linetype = "Maximum"), linewidth = 2) +
+      ggplot2::geom_point(ggplot2::aes(x = time_period, y = min_date, color = "Minimum"), size = 2.5, show.legend = FALSE) +
+      ggplot2::geom_point(ggplot2::aes(x = time_period, y = median_date, color = "Median"), size = 2.5, show.legend = FALSE) +
+      ggplot2::geom_point(ggplot2::aes(x = time_period, y = max_date, color = "Maximum"), size = 2.5, show.legend = FALSE) +
       ggplot2::scale_linetype_manual(name = "Stats",
                             values = c("Minimum" = "solid",
-                                       "Median" = "1212",
+                                       "Median" = "solid",
                                        "Maximum" = "solid"))
   } else if (nrow(var_data[!is.na(median_date)]) == 1){
     plot <-   ggplot2::ggplot(var_data[!is.na(median_date)]) +
@@ -1910,7 +1916,7 @@ plotDATE <- function(var_data, time_var, mytitle) {
     ggplot2::theme_bw() +
     ggplot2::theme(plot.title = ggplot2::element_text(hjust = 0.5),
           plot.subtitle = ggplot2::element_text(hjust = 0.5, face = 'bold', size = 16)) +
-    ggplot2::guides(color = ggplot2::guide_legend(override.aes = list(linetype = c("solid", "1212", "solid"))))
+    ggplot2::guides(color = ggplot2::guide_legend(override.aes = list(linetype = c("solid", "solid", "solid"))))
 
   return(plot)
 }

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -187,7 +187,7 @@ etl_qa_run_pipeline <- function(connection = NULL,
   } else if (data_source_type == 'sql_server' && is.null(connection)) {
     stop("\U0001f47f\nFor 'sql_server' data_source_type, a DBIConnection object must be provided for the connection argument")
   } else if (data_source_type != 'sql_server' && !is.null(connection)) {
-    warning("\U00026A0\nThe connection argument is ignored when data_source_type != 'sql_server'")
+    warning("\u26A0\ufe0f\nThe connection argument is ignored when data_source_type != 'sql_server'")
   }
 
   ## Validate data_params ----
@@ -209,7 +209,7 @@ etl_qa_run_pipeline <- function(connection = NULL,
   if((!'cols' %in% names(data_params) || is.null(data_params$cols) ) & isFALSE(data_params$check_chi)){
     stop("\U0001f47f\nYou must specify the 'data_params$cols' argument when data_params$check_chi is FALSE or not provided.")
   } else if ((!'cols' %in% names(data_params) || is.null(data_params$cols) ) & isTRUE(data_params$check_chi)){
-    warning("\U00026A0\nYou did not specify the 'data_params$cols' argument. Since data_params$check_chi = TRUE, the code will run, \n",
+    warning("\u26A0\ufe0f\nYou did not specify the 'data_params$cols' argument. Since data_params$check_chi = TRUE, the code will run, \n",
     "however it might encounter an error if there are no CHI related variables in your data.")
   }
 
@@ -482,7 +482,7 @@ etl_qa_setup_config <- function(data_source_type,
     }
   } else {
     output_directory <- getwd()
-    warning("\U00026A0\nNo output_directory specified. Using current working directory: ", output_directory, ".")
+    warning("\u26A0\ufe0f\nNo output_directory specified. Using current working directory: ", output_directory, ".")
   }
 
   # Validate check_chi
@@ -1003,7 +1003,7 @@ comp_2_chi_std <- function(myCHIcomparison, time_var){
                                   align = c('r', 'l', 'l', 'l'))
 
   if (nrow(only_chi) > 0){
-    message("\U0001f626\U0001f47f\U0001F92C\U00026A0 \n",
+    message("\U0001f626\U0001f47f\U0001F92C\u26A0\ufe0f \n",
             "The following varname and group combinations exist in the rads.data::misc_chi_byvars \n",
             "standards but are missing from your dataset. Please ensure your dataset complies with\n",
             "the CHI standard.\n\n",
@@ -1018,7 +1018,7 @@ comp_2_chi_std <- function(myCHIcomparison, time_var){
                                    format = "pipe",
                                    align = c('r', 'l', 'l'))
   if (nrow(only_your_data) > 0){
-    message("\U0001f626\U0001f47f\U0001F92C\U00026A0 \nThe following varname & group combinations in your table are not valid\n",
+    message("\U0001f626\U0001f47f\U0001F92C\u26A0\ufe0f \nThe following varname & group combinations in your table are not valid\n",
             "when compared to rads.data::misc_chi_byvars:\n\n",
             paste(formatted_table2, collapse = "\n"), '\n')
   }
@@ -1710,7 +1710,7 @@ etl_qa_export_results <- function(qa_results, config) {
   if(nrow(mi100) > 0){
     mi100vars <- paste0(unique(mi100$varname), collapse  = ', ') # string of all 100% missing separated by comma
     mi100vars <- sub(", ([^,]*)$", " & \\1", mi100vars) # replace last comma with ampersand
-    warning("\n\U00026A0\nThe following variables are 100% missing across all time points and therefore DO NOT have value plots:\n",
+    warning("\n\u26A0\ufe0f\nThe following variables are 100% missing across all time points and therefore DO NOT have value plots:\n",
             mi100vars, immediate.=TRUE)
     mi100vars <- unique(mi100$varname) # save a clean vector of all variables with 100% missing data
   } else {mi100vars <- c() }

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -770,7 +770,7 @@ process_r_dataframe <- function(config) {
     your_data <- data.table::rbindlist(lapply(chi_dtvars, function(col) {
       unique(dt[, list(varname = col,
                     group = as.character(.SD[[col]])),
-                by = chi_year,
+                by = get(config$time_var),
                 .SDcols = col
       ][, your_data := 1L])
     }))
@@ -781,13 +781,13 @@ process_r_dataframe <- function(config) {
     chi_std_comparison <- merge(your_data,
                                 chi_std,
                                 by = c('varname', 'group'),
-                                all = T)[, list(chi_year, varname, group, your_data, chi)]
+                                all = T)[, .SD, .SDcols = c(config$data_params$time_var, 'varname', 'group', 'your_data', 'chi')]
 
     chi_std_comparison[is.na(your_data), your_data := 0]
     chi_std_comparison[is.na(chi), chi := 0]
 
     # use summary function
-    comp_2_chi_std(chi_std_comparison)
+    comp_2_chi_std(chi_std_comparison, time_var = config$data_params$time_var)
   } else {
     chi_std_comparison = data.table::data.table() # create a data.table with zero columns and zero rows, just to have a data.table object so rest of code will work
   }
@@ -838,7 +838,7 @@ process_rads_data <- function(config) {
     unique(c(chivars,
              byvars,
              config$data_params$cols,
-             'chi_year',
+             config$data_params$time_var,
              ifelse(isTRUE(config$data_params$kingco), 'chi_geo_kc', '')
     )),
     possiblecols))
@@ -952,20 +952,22 @@ process_sql_server <- function(config) {
     categorical_freq <- categorical_freq[varname %in% unique(chi_std$varname)]
 
     # Tidy frequency table
-    categorical_freq <- categorical_freq[, list(chi_year, varname, group = value, your_data = 1L)]
+    categorical_freq <- categorical_freq[, .SD, .SDcols = c(config$data_params$time_var, 'varname', 'value')]
+    setnames(categorical_freq, 'value', 'group')
+    categorical_freq[, your_data := 1]
     categorical_freq <- categorical_freq[!is.na(group)]
 
     # Merge CHI standards onto actual data ----
     chi_std_comparison <- merge(categorical_freq,
                                 chi_std,
                                 by = c('varname', 'group'),
-                                all = T)[, list(chi_year, varname, group, your_data, chi)]
+                                all = T)[, .SD, .SDcols = c(config$data_params$time_var, 'varname', 'group', 'your_data', 'chi')]
 
     chi_std_comparison[is.na(your_data), your_data := 0]
     chi_std_comparison[is.na(chi), chi := 0]
 
     # use summary function
-    comp_2_chi_std(chi_std_comparison)
+    comp_2_chi_std(chi_std_comparison, time_var = config$data_params$time_var)
   } else {
     chi_std_comparison = data.table::data.table() # create a data.table with zero columns and zero rows, just to have a data.table object so rest of code will work
   }
@@ -988,7 +990,7 @@ process_sql_server <- function(config) {
 #' @noRd
 #'
 #'
-comp_2_chi_std <- function(myCHIcomparison){
+comp_2_chi_std <- function(myCHIcomparison, time_var){
   # Expects data.table with chi_year <integer>, varname <character>, group <character>, your_data <integer/logical>, chi <integer/logical>
   # Identify data in CHI standard table that is not in the dataset ----
   only_chi <- myCHIcomparison[your_data == 0][, list(varname, group)]
@@ -1010,7 +1012,7 @@ comp_2_chi_std <- function(myCHIcomparison){
 
   # Identify data in mydata that is not the CHI standard table ----
   only_your_data <- myCHIcomparison[chi == 0]
-  only_your_data <- only_your_data[, list(chi_year = rads::format_time(chi_year)), list(varname, group)]
+  only_your_data <- only_your_data[, list(chi_year = rads::format_time(get(time_var))), list(varname, group)]
   data.table::setorder(only_your_data, varname, group)
   formatted_table2 <- knitr::kable(only_your_data[, list(chi_year, varname, group)],
                                    format = "pipe",

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -953,7 +953,7 @@ process_sql_server <- function(config) {
 
     # Tidy frequency table
     categorical_freq <- categorical_freq[, .SD, .SDcols = c(config$data_params$time_var, 'varname', 'value')]
-    setnames(categorical_freq, 'value', 'group')
+    data.table::setnames(categorical_freq, 'value', 'group')
     categorical_freq[, your_data := 1]
     categorical_freq <- categorical_freq[!is.na(group)]
 

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -1800,7 +1800,9 @@ plotCATEGORICAL <- function(var_data, time_var, mytitle) {
   ggplot2::ggplot(var_data, ggplot2::aes(x = time_period, y = proportion, color = value, linetype = value)) +
     ggplot2::geom_line(ggplot2::aes(linewidth = ifelse(is.na(value), 1.5, 2))) +
     ggplot2::geom_point(size = 2.5, show.legend = FALSE) +
-    ggplot2::scale_x_continuous(name = time_var, breaks = seq(min(var_data[['time_period']]), max(var_data[['time_period']]), length.out = 5)) +
+    ggplot2::scale_x_continuous(name = time_var,
+                                breaks = scales::breaks_pretty(n = 10),
+                                labels = scales::label_number(accuracy = 1, big.mark = '')) +
     ggplot2::scale_y_continuous(limits = c(0, 1)) +
     ggplot2::scale_color_manual(values = c(scales::hue_pal()(length(unique(stats::na.omit(var_data$value)))), "black"),
                        na.value = "black") +
@@ -1863,7 +1865,9 @@ plotCONTINUOUS <- function(var_data, time_var, mytitle) {
                                   "Median" = "#ABDDA4",
                                   "Maximum" = "#FDAE61")) +
 
-    ggplot2::scale_x_continuous(name = time_var, breaks = seq(min(var_data[['time_period']]), max(var_data[['time_period']]), length.out = 5)) +
+    ggplot2::scale_x_continuous(name = time_var,
+                                breaks = scales::breaks_pretty(n = 10),
+                                labels = scales::label_number(accuracy = 1, big.mark = '')) +
     ggplot2::labs(title = mytitle, subtitle = paste0('', var_data$varname[1]), x = time_var, y = var_data$varname[1]) +
     ggplot2::theme_bw() +
     ggplot2::theme(plot.title = ggplot2::element_text(hjust = 0.5),
@@ -1911,7 +1915,9 @@ plotDATE <- function(var_data, time_var, mytitle) {
                        values = c("Minimum" = "#2C7BB6",
                                   "Median" = "#ABDDA4",
                                   "Maximum" = "#FDAE61")) +
-    ggplot2::scale_x_continuous(name = time_var, breaks = seq(min(var_data[['time_period']]), max(var_data[['time_period']]), length.out = 5)) +
+    ggplot2::scale_x_continuous(name = time_var,
+                                breaks = scales::breaks_pretty(n = 10),
+                                labels = scales::label_number(accuracy = 1, big.mark = '')) +
     ggplot2::scale_y_date(date_labels = "%Y-%m-%d",
                  limits = c(min(var_data$min_date), max(var_data$max_date)),
                  # date_breaks = "5 year" # commented out because never know the scale of dates being assessed
@@ -1943,7 +1949,9 @@ plotMISSING <- function(plot_data, time_var, mytitle) {
       ggplot2::geom_point(size = 2.5) +
       ggplot2::geom_line(linewidth = 2) +
       ggplot2::facet_wrap('varname', ncol = 4) +
-      ggplot2::scale_x_continuous(name = time_var, breaks = seq(min(plot_data[['time_period']]), max(plot_data[['time_period']]), length.out = 5)) +
+      ggplot2::scale_x_continuous(name = time_var,
+                                  breaks = scales::breaks_pretty(n = 8),
+                                  labels = scales::label_number(accuracy = 1, big.mark = '')) +
       ggplot2::scale_y_continuous(limits = c(0, 1), labels = scales::percent_format(accuracy = 1L)) +
       ggplot2::ylab('Percent missing') +
       ggplot2::ggtitle(mytitle) +

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -1824,6 +1824,9 @@ plotCATEGORICAL <- function(var_data, time_var, mytitle) {
 #' @noRd
 #'
 plotCONTINUOUS <- function(var_data, time_var, mytitle) {
+  # Drop rows for years without data because some questions asked alternating years
+    var_data <- var_data[!is.na(mean)]
+
   # Typical case where there is more than 1 row of data
   if(nrow(var_data[!is.na(mean)]) > 1){
     plot <- ggplot2::ggplot(var_data) +
@@ -1831,10 +1834,14 @@ plotCONTINUOUS <- function(var_data, time_var, mytitle) {
       ggplot2::geom_line(ggplot2::aes(x = time_period, y = mean, color = "Mean", linetype = "Mean"), linewidth = 1.5) +
       ggplot2::geom_line(ggplot2::aes(x = time_period, y = median, color = "Median", linetype = "Median"), linewidth = 1.5) +
       ggplot2::geom_line(ggplot2::aes(x = time_period, y = max, color = "Maximum", linetype = "Maximum"), linewidth = 2) +
+      ggplot2::geom_point(ggplot2::aes(x = time_period, y = min, color = "Minimum"), size = 2.5, show.legend = FALSE) +
+      ggplot2::geom_point(ggplot2::aes(x = time_period, y = mean, color = "Mean"), size = 2.5, show.legend = FALSE) +
+      ggplot2::geom_point(ggplot2::aes(x = time_period, y = median, color = "Median"), size = 2.5, show.legend = FALSE) +
+      ggplot2::geom_point(ggplot2::aes(x = time_period, y = max, color = "Maximum"), size = 2.5, show.legend = FALSE) +
       ggplot2::scale_linetype_manual(name = "Stats",
                             values = c("Minimum" = "solid",
-                                       "Mean" = "dotted",
-                                       "Median" = "1212",
+                                       "Mean" = "solid",
+                                       "Median" = "solid",
                                        "Maximum" = "solid"))
 
   } else if (nrow(var_data[!is.na(mean)]) == 1) {
@@ -1857,7 +1864,7 @@ plotCONTINUOUS <- function(var_data, time_var, mytitle) {
     ggplot2::theme_bw() +
     ggplot2::theme(plot.title = ggplot2::element_text(hjust = 0.5),
           plot.subtitle = ggplot2::element_text(hjust = 0.5, face = 'bold', size = 16)) +
-    ggplot2::guides(color = ggplot2::guide_legend(override.aes = list(linetype = c("solid", "dotted", "1212", "solid"))))
+    ggplot2::guides(color = ggplot2::guide_legend(override.aes = list(linetype = c("solid", "solid", "solid", "solid"))))
 
   return(plot)
 }

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -1860,10 +1860,10 @@ plotCONTINUOUS <- function(var_data, time_var, mytitle) {
 
   plot <- plot +
     ggplot2::scale_color_manual(name = "Stats",
-                       values = c("Minimum" = "#2C7BB6",
-                                  "Mean" = "#D7191C",
-                                  "Median" = "#ABDDA4",
-                                  "Maximum" = "#FDAE61")) +
+                       values = c("Minimum" = "#a6cee3",
+                                  "Mean" = "#1f78b4",
+                                  "Median" = "#b2df8a",
+                                  "Maximum" = "#33a02c")) +
 
     ggplot2::scale_x_continuous(name = time_var,
                                 breaks = scales::breaks_pretty(n = 10),
@@ -1912,9 +1912,9 @@ plotDATE <- function(var_data, time_var, mytitle) {
 
   plot <- plot +
     ggplot2::scale_color_manual(name = "Stats",
-                       values = c("Minimum" = "#2C7BB6",
-                                  "Median" = "#ABDDA4",
-                                  "Maximum" = "#FDAE61")) +
+                       values = c("Minimum" = "#a6cee3",
+                                  "Median" = "#b2df8a",
+                                  "Maximum" = "#33a02c")) +
     ggplot2::scale_x_continuous(name = time_var,
                                 breaks = scales::breaks_pretty(n = 10),
                                 labels = scales::label_number(accuracy = 1, big.mark = '')) +

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -135,7 +135,7 @@
 #'
 #' # Example with SQL Server
 #' library(DBI)
-#' myconnection <- rads::validate_hhsaw_key()
+#' myconnection <- apde.data::authenticate_hhsaw()
 #' qa.sql <- etl_qa_run_pipeline(
 #'   data_source_type = 'sql_server',
 #'   connection = myconnection,
@@ -435,7 +435,7 @@ etl_qa_run_pipeline <- function(connection = NULL,
 #'
 #' # Example with SQL Server
 #' library(DBI)
-#' myconnection <- rads::validate_hhsaw_key()
+#' myconnection <- apde.data::authenticate_hhsaw()
 #' config.sql <- etl_qa_setup_config(
 #'   data_source_type = 'sql_server',
 #'   connection = myconnection,

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -1789,6 +1789,9 @@ etl_qa_export_results <- function(qa_results, config) {
 #'
 #'
 plotCATEGORICAL <- function(var_data, time_var, mytitle) {
+  # Drop rows for years without data because some questions asked alternating years
+  var_data <- var_data[, if(any(proportion != 0)) .SD, by = time_period]
+
   value_levels <- levels(factor(var_data$value, exclude = NULL))
   linetypes <- rep("solid", length(value_levels))
   names(linetypes) <- value_levels
@@ -1796,6 +1799,7 @@ plotCATEGORICAL <- function(var_data, time_var, mytitle) {
 
   ggplot2::ggplot(var_data, ggplot2::aes(x = time_period, y = proportion, color = value, linetype = value)) +
     ggplot2::geom_line(ggplot2::aes(linewidth = ifelse(is.na(value), 1.5, 2))) +
+    ggplot2::geom_point(size = 2.5, show.legend = FALSE) +
     ggplot2::scale_x_continuous(name = time_var, breaks = seq(min(var_data[['time_period']]), max(var_data[['time_period']]), length.out = 5)) +
     ggplot2::scale_y_continuous(limits = c(0, 1)) +
     ggplot2::scale_color_manual(values = c(scales::hue_pal()(length(unique(stats::na.omit(var_data$value)))), "black"),

--- a/R/etl_qa_run_pipeline.R
+++ b/R/etl_qa_run_pipeline.R
@@ -823,7 +823,8 @@ process_rads_data <- function(config) {
   }
 
   # Identify CHI variables (if needed) ----
-  possiblecols <- rads::quiet(rads::list_dataset_columns(gsub('get_data_', '', config$data_params$function_name))[]$var.names)
+  possiblecols <- rads::quiet(apde.data::list_data_columns(gsub('get_data_', '', config$data_params$function_name))[]$var.names)
+
 
   if(!config$data_params$time_var %in% possiblecols){
     stop("\U1F6D1\nThe variable specified in data_params$time_var is not available in this dataset.")

--- a/man/etl_qa_final_results.Rd
+++ b/man/etl_qa_final_results.Rd
@@ -16,7 +16,7 @@ A list containing formatted and combined results that consists of:
 \itemize{
 \item \code{missingness}: Structured summary of the proportion of missing data per variable and time point
 \item \code{values}: Combined table with the frequency of categorical variables and simple statistics for numeric and date / datetime variables
-\item \code{chi_standards}: Comparison of CHI (Community Health Indicator) variables values with those expected based on \code{rads.data::misc_chi_byvars}
+\item \code{chi_standards}: Comparison of CHI (Community Health Indicator) variables values with those expected based on \code{apde.chi.tools::chi_standard_varnames}
 }
 }
 \description{

--- a/man/etl_qa_initial_results.Rd
+++ b/man/etl_qa_initial_results.Rd
@@ -18,7 +18,7 @@ A list of raw analytic output. The table structure may differ slightly depending
 \item \code{vals_categorical}: A frequency table of the top 8 most frequent values
 of categorical variable (and numerics or dates with < your specified \code{distinct_threshold} distinct values) PLUS a rows for \code{NA}
 PLUS a row for all 'Other values'
-\item \code{chi_standards}: Comparison of CHI (Community Health Indicator) variables values with those expected based on \code{rads.data::misc_chi_byvars}
+\item \code{chi_standards}: Comparison of CHI (Community Health Indicator) variables values with those expected based on \code{apde.chi.tools::chi_standard_varnames}
 }
 }
 \description{

--- a/man/etl_qa_run_pipeline.Rd
+++ b/man/etl_qa_run_pipeline.Rd
@@ -29,7 +29,7 @@ parameters are needed for all data sources. Please review the examples for detai
 \item \code{check_chi}: Logical vector of length 1. When \code{check_chi = TRUE},
 function will add any available CHI related variables to \code{cols} and
 will assess whether their values align with standards in
-\code{rads.data::misc_chi_byvars}. Default is \code{FALSE}
+\code{apde.chi.tools::chi_standard_varnames}. Default is \code{FALSE}
 \item \code{cols}: Character vector specifying the column names to analyze,
 e.g., \code{cols = c('race4', 'birth_weight_grams', 'birthplace_city')}
 \item \code{time_range}: Character vector of length 2 specifying the start

--- a/tests/manual/test-etl_qa_run_pipeline.R
+++ b/tests/manual/test-etl_qa_run_pipeline.R
@@ -16,9 +16,9 @@ library(apde.etl)
     myOutputFolder <- tempdir()
 
   ## Create connections ----
-    myconnection <- rads::validate_hhsaw_key()
+    myconnection <- apde.data::authenticate_hhsaw()
 
-    myNEWconnection <- rads::validate_hhsaw_key()
+    myNEWconnection <- apde.data::authenticate_hhsaw()
     DBI::dbDisconnect(myNEWconnection) # disconnected DBIconnection needed to throw the error message below
 
   ## Create synthetic data & estimates for testing numeric arguments ----

--- a/tests/manual/test-etl_qa_run_pipeline.R
+++ b/tests/manual/test-etl_qa_run_pipeline.R
@@ -68,7 +68,7 @@ library(apde.etl)
       data_source_type = 'rads',
       data_params = list(
         function_name = 'get_data_birth',
-        time_var = 'chi_year',
+        time_var = 'date_of_birth_year',
         time_range = c(2021, 2022),
         cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
                  'num_prev_cesarean', 'mother_date_of_birth'),
@@ -84,13 +84,13 @@ library(apde.etl)
                                        kingco = F,
                                        cols = c('chi_age', 'race4', 'birth_weight_grams',
                                                 'birthplace_city', 'num_prev_cesarean',
-                                                'chi_year', 'mother_date_of_birth'),
+                                                'date_of_birth_year', 'mother_date_of_birth'),
     )
     qa.df <- etl_qa_run_pipeline(
       data_source_type = 'r_dataframe',
       data_params = list(
         data = birth_data,
-        time_var = 'chi_year',
+        time_var = 'date_of_birth_year',
         time_range = c(2021, 2022),
         cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
                  'num_prev_cesarean', 'mother_date_of_birth'),
@@ -105,7 +105,7 @@ library(apde.etl)
       connection = myconnection,
       data_params = list(
         schema_table = 'birth.final_analytic',
-        time_var = 'chi_year',
+        time_var = 'date_of_birth_year',
         time_range = c(2021, 2022),
         cols =c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
                 'num_prev_cesarean', 'mother_date_of_birth'),
@@ -120,7 +120,7 @@ library(apde.etl)
       connection = myconnection,
       data_params = list(
         schema_table = 'birth.final_analytic',
-        time_var = 'chi_year',
+        time_var = 'date_of_birth_year',
         time_range = c(2021, 2022),
         cols =c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
                 'num_prev_cesarean', 'mother_date_of_birth'),

--- a/tests/manual/test-etl_qa_run_pipeline.R
+++ b/tests/manual/test-etl_qa_run_pipeline.R
@@ -1,66 +1,68 @@
 library(rads)
 library(data.table)
 library(DBI)
+library(testthat)
+library(apde.etl)
 
 # Notes ----
-# Tests should usually be self contained, but the nature of these functions 
+# Tests should usually be self contained, but the nature of these functions
 # necessitates testing with our infrastructure
 
-# For efficiency, will only test the highest level function since it calls on all 
-# sub functions. 
+# For efficiency, will only test the highest level function since it calls on all
+# sub functions.
 
 # Set up directories, connections, data, and estimates for testing below ----
   ## Create a temporary directory to save output ----
     myOutputFolder <- tempdir()
-  
+
   ## Create connections ----
     myconnection <- rads::validate_hhsaw_key()
 
     myNEWconnection <- rads::validate_hhsaw_key()
     DBI::dbDisconnect(myNEWconnection) # disconnected DBIconnection needed to throw the error message below
-    
+
   ## Create synthetic data & estimates for testing numeric arguments ----
     set.seed(98104)
     synthetic_data <- data.table(
-      myyear = sample(2011:2020, size = 10000, replace = T), 
-      mycategorical = factor(sample(c('alpha', 'beta', 'gamma', 'delta'), size = 10000, replace = T)), 
+      myyear = sample(2011:2020, size = 10000, replace = T),
+      mycategorical = factor(sample(c('alpha', 'beta', 'gamma', 'delta'), size = 10000, replace = T)),
       myinteger = rnorm(10000, mean = 5000, sd = 300))
     synthetic_data[sample(200), mycategorical := NA]
     synthetic_data[sample(which(synthetic_data$myyear == 2016), 40), mycategorical := NA] # extra missing for 2016
     synthetic_data[sample(350), myinteger := NA]
-    
+
     synthetic_1 <- etl_qa_run_pipeline(
       data_source_type = 'r_dataframe',
       data_params = list(
         data = synthetic_data,
         time_var = 'myyear',
         time_range = c(2011, 2020),
-        cols = c('mycategorical', 'myinteger'), 
+        cols = c('mycategorical', 'myinteger'),
         check_chi = FALSE
-      ), 
-      output_directory = myOutputFolder, 
-      digits_mean = 0, 
-      digits_prop = 3, 
-      abs_threshold = 3, 
+      ),
+      output_directory = myOutputFolder,
+      digits_mean = 0,
+      digits_prop = 3,
+      abs_threshold = 3,
       rel_threshold = 2
     )
-    
+
     synthetic_2 <- etl_qa_run_pipeline(
       data_source_type = 'r_dataframe',
       data_params = list(
         data = synthetic_data,
         time_var = 'myyear',
         time_range = c(2011, 2020),
-        cols = c('mycategorical', 'myinteger'), 
+        cols = c('mycategorical', 'myinteger'),
         check_chi = FALSE
-      ), 
-      output_directory = myOutputFolder, 
-      digits_mean = 3, 
-      digits_prop = 5, 
-      abs_threshold = 1, 
+      ),
+      output_directory = myOutputFolder,
+      digits_mean = 3,
+      digits_prop = 5,
+      abs_threshold = 1,
       rel_threshold = 0
     )
-  
+
   ## Generic run with RADS ----
     qa.rads <- etl_qa_run_pipeline(
       data_source_type = 'rads',
@@ -68,21 +70,21 @@ library(DBI)
         function_name = 'get_data_birth',
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city', 
+        cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
                  'num_prev_cesarean', 'mother_date_of_birth'),
-        version = 'final', 
-        kingco = FALSE, 
+        version = 'final',
+        kingco = FALSE,
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
-  
+
   ## Generic run with R dataframe ----
-    birth_data <- rads::get_data_birth(year = c(2021:2022), 
-                                       kingco = F, 
-                                       cols = c('chi_age', 'race4', 'birth_weight_grams', 
-                                                'birthplace_city', 'num_prev_cesarean', 
-                                                'chi_year', 'mother_date_of_birth'), 
+    birth_data <- rads::get_data_birth(year = c(2021:2022),
+                                       kingco = F,
+                                       cols = c('chi_age', 'race4', 'birth_weight_grams',
+                                                'birthplace_city', 'num_prev_cesarean',
+                                                'chi_year', 'mother_date_of_birth'),
     )
     qa.df <- etl_qa_run_pipeline(
       data_source_type = 'r_dataframe',
@@ -90,10 +92,10 @@ library(DBI)
         data = birth_data,
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city', 
-                 'num_prev_cesarean', 'mother_date_of_birth'), 
+        cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
+                 'num_prev_cesarean', 'mother_date_of_birth'),
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
 
@@ -105,13 +107,13 @@ library(DBI)
         schema_table = 'birth.final_analytic',
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols =c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city', 
-                'num_prev_cesarean', 'mother_date_of_birth'), 
+        cols =c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
+                'num_prev_cesarean', 'mother_date_of_birth'),
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
-  
+
   ## Generic run with SQL Server & check_chi = TRUE ----
     qa.sqlchi <- etl_qa_run_pipeline(
       data_source_type = 'sql_server',
@@ -120,47 +122,47 @@ library(DBI)
         schema_table = 'birth.final_analytic',
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols =c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city', 
-                'num_prev_cesarean', 'mother_date_of_birth'), 
+        cols =c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
+                'num_prev_cesarean', 'mother_date_of_birth'),
         check_chi = TRUE
-      ), 
+      ),
       output_directory = myOutputFolder
-    )  
-  
+    )
+
 # test etl_qa_run_pipeline functionality ----
   test_that("Identical names of objects in the returned result list", {
-    expect_identical(names(qa.rads), names(qa.df)) 
-    expect_identical(names(qa.rads), names(qa.sql)) 
-  })  
-  
+    expect_identical(names(qa.rads), names(qa.df))
+    expect_identical(names(qa.rads), names(qa.sql))
+  })
+
   test_that("Results are identical regardless of method of accessing data", {
     expect_identical(qa.rads$final, qa.df$final)
     expect_identical(qa.rads$final, qa.sql$final)
   })
-  
+
   test_that("1 Excel file and 2 PDF files were exported", {
     expect_true(file.exists(qa.rads$exported$pdf_missing))
     expect_true(file.exists(qa.rads$exported$pdf_values))
     expect_true(file.exists(qa.rads$exported$excel))
-    
+
     expect_true(file.exists(qa.df$exported$pdf_missing))
     expect_true(file.exists(qa.df$exported$pdf_values))
     expect_true(file.exists(qa.df$exported$excel))
-    
+
     expect_true(file.exists(qa.sql$exported$pdf_missing))
     expect_true(file.exists(qa.sql$exported$pdf_values))
     expect_true(file.exists(qa.sql$exported$excel))
   })
-  
+
   test_that('chi_check = TRUE works as expected', {
     # all specified cols are still there when use chi_check = TRUE
     expect_true(all(qa.sql$final$missingness$varname %in% qa.sqlchi$final$missingness$varname))
-    
+
     # chi_check = TRUE returns additional cols, at least 20 of which begin with 'chi'
-    expect_gt(sum(grepl('^chi_', setdiff(unique(qa.sqlchi$final$missingness$varname), unique(qa.sql$final$missingness$varname)))), 
+    expect_gt(sum(grepl('^chi_', setdiff(unique(qa.sqlchi$final$missingness$varname), unique(qa.sql$final$missingness$varname)))),
               20)
   })
-  
+
   test_that('Ensure `kingco` = TRUE works as expected', {
     KCfalse <- etl_qa_run_pipeline(
       data_source_type = 'rads',
@@ -169,13 +171,13 @@ library(DBI)
         time_var = 'chi_year',
         time_range = c(2021, 2022),
         cols = c('chi_geo_kc'),
-        version = 'final', 
-        kingco = FALSE, 
+        version = 'final',
+        kingco = FALSE,
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
-    
+
     KCtrue <- etl_qa_run_pipeline(
       data_source_type = 'rads',
       data_params = list(
@@ -183,16 +185,16 @@ library(DBI)
         time_var = 'chi_year',
         time_range = c(2021, 2022),
         cols = c('chi_geo_kc'),
-        version = 'final', 
-        kingco = TRUE, 
+        version = 'final',
+        kingco = TRUE,
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
-    
+
     expect_gt(sum(KCfalse$final$values$count, na.rm = T), sum(KCtrue$final$values$count, na.rm = T))
   })
-  
+
   test_that('Ensure processing a single numeric, or character, or date var at a time does not cause problems', {
     # test for both rads and SQL, to effectively test all options since rads uses the data.frame/data.table code
     # character only ----
@@ -203,16 +205,16 @@ library(DBI)
         time_var = 'chi_year',
         time_range = c(2021, 2022),
         cols = c('chi_geo_kc'),
-        version = 'final', 
-        kingco = FALSE, 
+        version = 'final',
+        kingco = FALSE,
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
-    
+
     expect_identical(names(qa.rads.char), c('config', 'initial', 'final', 'exported'))
     expect_equal(nrow(qa.rads.char$final$values), 6) # two rows for chi_geo_KC == 'King County' and two rows where is.na(chi_geo_kc) and empty rows for continous and dates
-    
+
     qa.sql.char <- etl_qa_run_pipeline(
       data_source_type = 'sql_server',
       connection = myconnection,
@@ -220,14 +222,14 @@ library(DBI)
         schema_table = 'birth.final_analytic',
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols =c('chi_geo_kc'), 
+        cols =c('chi_geo_kc'),
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
     expect_identical(names(qa.sql.char), c('config', 'initial', 'final', 'exported'))
     expect_equal(nrow(qa.sql.char$final$values), 6)
-    
+
     # continuous only ----
     qa.rads.cont <- etl_qa_run_pipeline(
       data_source_type = 'rads',
@@ -236,16 +238,16 @@ library(DBI)
         time_var = 'chi_year',
         time_range = c(2021, 2022),
         cols = c('birth_weight_grams'),
-        version = 'final', 
-        kingco = FALSE, 
+        version = 'final',
+        kingco = FALSE,
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
-    
+
     expect_identical(names(qa.rads.cont), c('config', 'initial', 'final', 'exported'))
     expect_equal(nrow(qa.rads.cont$final$values), 4) # two years for continuous plus emptry rows for character and date
-    
+
     qa.sql.cont <- etl_qa_run_pipeline(
       data_source_type = 'sql_server',
       connection = myconnection,
@@ -253,14 +255,14 @@ library(DBI)
         schema_table = 'birth.final_analytic',
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols =c('birth_weight_grams'), 
+        cols =c('birth_weight_grams'),
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
     expect_identical(names(qa.sql.cont), c('config', 'initial', 'final', 'exported'))
     expect_equal(nrow(qa.sql.cont$final$values), 4)
-    
+
     # date only ----
     qa.rads.date <- etl_qa_run_pipeline(
       data_source_type = 'rads',
@@ -269,16 +271,16 @@ library(DBI)
         time_var = 'chi_year',
         time_range = c(2021, 2022),
         cols = c('mother_date_of_birth'),
-        version = 'final', 
-        kingco = FALSE, 
+        version = 'final',
+        kingco = FALSE,
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
-    
+
     expect_identical(names(qa.rads.date), c('config', 'initial', 'final', 'exported'))
     expect_equal(nrow(qa.rads.date$final$values), 4) # two years for dates plus empty row for categorical and continous
-    
+
     qa.sql.date <- etl_qa_run_pipeline(
       data_source_type = 'sql_server',
       connection = myconnection,
@@ -286,51 +288,51 @@ library(DBI)
         schema_table = 'birth.final_analytic',
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols =c('mother_date_of_birth'), 
+        cols =c('mother_date_of_birth'),
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
     )
     expect_identical(names(qa.sql.date), c('config', 'initial', 'final', 'exported'))
     expect_equal(nrow(qa.sql.date$final$values), 4)
   })
-  
+
   test_that('Ensure `digits_prop` rounds proportion as expected', {
     # rounding to 3 digits (default)
     expect_equal(synthetic_1$final$missingness$proportion, round(synthetic_1$final$missingness$proportion, 3))
     expect_equal(synthetic_1$final$values$proportion, rads::round2(synthetic_1$final$value$proportion, 3))
-    
+
     # rounding to 5 digits
     expect_equal(synthetic_2$final$missingness$proportion, round(synthetic_2$final$missingness$proportion, 5))
-    expect_equal(synthetic_2$final$values$proportion, rads::round2(synthetic_2$final$value$proportion, 5))            
+    expect_equal(synthetic_2$final$values$proportion, rads::round2(synthetic_2$final$value$proportion, 5))
   })
 
   test_that('Ensure `digits_mean` rounds mean, median, min, & max as expected', {
     # rounding to 0 digits (default)
     expect_equal(synthetic_1$final$values[!is.na(mean)]$mean, rads::round2(synthetic_1$final$values[!is.na(mean)]$mean, 0))
     expect_equal(synthetic_1$final$values[!is.na(mean)]$median, rads::round2(synthetic_1$final$values[!is.na(median)]$median, 0))
-    
+
     # rounding to 3 digits
     expect_equal(synthetic_2$final$values[!is.na(mean)]$mean, rads::round2(synthetic_2$final$values[!is.na(mean)]$mean, 3))
-    expect_equal(synthetic_2$final$values[!is.na(mean)]$median, rads::round2(synthetic_2$final$values[!is.na(median)]$median, 3))      
+    expect_equal(synthetic_2$final$values[!is.na(mean)]$median, rads::round2(synthetic_2$final$values[!is.na(median)]$median, 3))
   })
-  
+
   test_that('Ensure `abs_threshold` changes the reporting threshhold for absolute changes in proportions', {
     # expect test2 to have more absolute changes because we lowered the the threshold, so more changes should be recorded
     expect_gte(
-      length(abs(as.numeric(gsub('%', '', synthetic_2$final$missing[!is.na(abs_change)]$abs_change)))), 
+      length(abs(as.numeric(gsub('%', '', synthetic_2$final$missing[!is.na(abs_change)]$abs_change)))),
       length(abs(as.numeric(gsub('%', '', synthetic_1$final$missing[!is.na(abs_change)]$abs_change))))
-    )      
+    )
   })
 
   test_that('Ensure `rel_threshold` changes the reporting threshhold for absolute changes in means & medians', {
     # expect test2 to have more relative changes because we lowered the the threshold, so more changes should be recorded
     expect_gte(
-      length(abs(as.numeric(gsub('%', '', synthetic_2$final$values[!is.na(rel_mean_change )]$rel_mean_change )))), 
+      length(abs(as.numeric(gsub('%', '', synthetic_2$final$values[!is.na(rel_mean_change )]$rel_mean_change )))),
       length(abs(as.numeric(gsub('%', '', synthetic_1$final$values[!is.na(rel_mean_change )]$rel_mean_change )))))
-    
+
     expect_gte(
-      length(abs(as.numeric(gsub('%', '', synthetic_2$final$values[!is.na(rel_median_change )]$rel_median_change )))), 
+      length(abs(as.numeric(gsub('%', '', synthetic_2$final$values[!is.na(rel_median_change )]$rel_median_change )))),
       length(abs(as.numeric(gsub('%', '', synthetic_1$final$values[!is.na(rel_median_change )]$rel_median_change )))))
   })
 
@@ -344,14 +346,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "data_source_type must be one of 'r_dataframe', 'sql_server', or 'rads'"
     )})
-  
+
   test_that("Need a valid output directory", {
     expect_error(
       test <- etl_qa_run_pipeline(
@@ -361,16 +363,16 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = 'X:/randomDir/randomDir2'
-      ), 
+      ),
       "You have specified an output_directory that does not exist."
     )})
-    
+
   test_that("Need to submit a valid DBI connection", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -379,14 +381,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "For 'sql_server' data_source_type, connection must be a DBIConnection object"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -395,14 +397,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "For 'sql_server' data_source_type, a DBIConnection object must be provided for the connection argument"
     )
-    
+
 
     expect_error(
       test <- etl_qa_run_pipeline(
@@ -412,16 +414,16 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "It may have been disconnected"
     )
-    
+
     })
-  
+
   test_that("Need data_params to be list", {
     expect_error(
     test <- etl_qa_run_pipeline(
@@ -431,15 +433,15 @@ library(DBI)
         schema_table = 'birth.final_analytic',
         time_var = 'chi_year',
         time_range = c(2021, 2022),
-        cols = c('chi_age'), 
+        cols = c('chi_age'),
         check_chi = FALSE
-      ), 
+      ),
       output_directory = myOutputFolder
-    ), 
+    ),
     "data_params must be a list"
   )
   })
-  
+
   test_that("Need data_params$check_chi to be a logical", {
     expect_error(
       test <- etl_qa_run_pipeline(
@@ -449,17 +451,17 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols = c('chi_age'), 
+          cols = c('chi_age'),
           check_chi = 'FALSE'
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "must be a logical "
     )
   })
-  
+
   test_that("Specification of data_params$cols", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -468,14 +470,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols = c(''), 
+          cols = c(''),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "No valid 'cols' have been selected"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -484,17 +486,17 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          # cols = c('chi_age'), 
+          # cols = c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "must specify the 'data_params\\$cols' argument"
     )
   })
-  
+
   test_that("Specification of data_params$time_range", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -503,14 +505,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2022),
-          cols = c('chi_age'), 
+          cols = c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "`data_params\\$time_range` must be provided and must be a numeric or integer vector of length 2."
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -519,14 +521,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           # time_range = c(2021, 2022),
-          cols = c('chi_age'), 
+          cols = c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "`data_params\\$time_range` must be provided and must be a numeric or integer vector of length 2."
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -535,17 +537,17 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2022, 2021),
-          cols = c('chi_age'), 
+          cols = c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "The first value of `data_params\\$time_range` must be less than or equal to the second value."
     )
   })
 
   test_that("Specification of data_params$time_var", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -554,14 +556,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = 'myyear',
           time_range = c(2021, 2022),
-          cols = c('chi_age'), 
+          cols = c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "is not available in this dataset"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -570,14 +572,14 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           time_var = c('chi_year', 'date_of_birth_year'),
           time_range = c(2021, 2022),
-          cols = c('chi_age'), 
+          cols = c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "`data_params\\$time_var` must be the name of a single time variable"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -586,17 +588,17 @@ library(DBI)
           schema_table = 'birth.final_analytic',
           # time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols = c('chi_age'), 
+          cols = c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "`data_params\\$time_var` is missing and must be provided."
     )
   })
-  
+
   test_that("Specification of data_params$data", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -604,15 +606,15 @@ library(DBI)
           # data = birth_data,
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city', 
-                   'num_prev_cesarean', 'mother_date_of_birth'), 
+          cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
+                   'num_prev_cesarean', 'mother_date_of_birth'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "For 'r_dataframe' type, data_params must include a 'data' element that is a data.frame or data.table"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -620,19 +622,19 @@ library(DBI)
           data = birth_datax,
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city', 
-                   'num_prev_cesarean', 'mother_date_of_birth'), 
+          cols = c('chi_age', 'race4', 'birth_weight_grams', 'birthplace_city',
+                   'num_prev_cesarean', 'mother_date_of_birth'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "object 'birth_datax' not found"
-    )    
-    
-  })  
-  
+    )
+
+  })
+
   test_that("Specification of data_params$function_name", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'rads',
@@ -641,15 +643,15 @@ library(DBI)
           time_var = 'chi_year',
           time_range = c(2021, 2022),
           cols = c('chi_age'),
-          version = 'final', 
-          kingco = FALSE, 
+          version = 'final',
+          kingco = FALSE,
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "The data_params\\$function_name you provided is invalid."
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'rads',
@@ -658,19 +660,19 @@ library(DBI)
           time_var = 'chi_year',
           time_range = c(2021, 2022),
           cols = c('chi_age'),
-          version = 'final', 
-          kingco = FALSE, 
+          version = 'final',
+          kingco = FALSE,
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "For 'rads' data_source_type, data_params must include a 'function_name'."
-    )    
-    
-  })  
-  
+    )
+
+  })
+
   test_that("Specification of data_params$kingco", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'rads',
@@ -679,15 +681,15 @@ library(DBI)
           time_var = 'chi_year',
           time_range = c(2021, 2022),
           cols = c('chi_age'),
-          version = 'final', 
-          kingco = 'FALSE', 
+          version = 'final',
+          kingco = 'FALSE',
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "If provided, `data_params\\$kingco` must be a single logical value"
     )
-    
+
     expect_message(
       test <- etl_qa_run_pipeline(
         data_source_type = 'rads',
@@ -696,19 +698,19 @@ library(DBI)
           time_var = 'chi_year',
           time_range = c(2021, 2022),
           cols = c('chi_age'),
-          version = 'final', 
-          #kingco = FALSE, 
+          version = 'final',
+          #kingco = FALSE,
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "Defaulting to TRUE"
-    )    
-    
-  })  
-  
+    )
+
+  })
+
   test_that("Specification of data_params$version", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'rads',
@@ -717,15 +719,15 @@ library(DBI)
           time_var = 'chi_year',
           time_range = c(2021, 2022),
           cols = c('chi_age'),
-          version = 'blah', 
-          kingco = FALSE, 
+          version = 'blah',
+          kingco = FALSE,
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "Invalid value for data_params\\$version. It must be either 'stage' or 'final'."
     )
-    
+
     expect_message(
       test <- etl_qa_run_pipeline(
         data_source_type = 'rads',
@@ -734,19 +736,19 @@ library(DBI)
           time_var = 'chi_year',
           time_range = c(2021, 2022),
           cols = c('chi_age'),
-          # version = 'final', 
-          kingco = FALSE, 
+          # version = 'final',
+          kingco = FALSE,
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "Defaulting to 'stage'"
-    )    
-    
-  })  
-  
+    )
+
+  })
+
   test_that("Specification of data_params$schema_table", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -755,14 +757,14 @@ library(DBI)
           # schema_table = 'birth.final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "For 'sql_server' data_source_type, data_params\\$schema_table must be provided in the format 'schema.table'"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -771,14 +773,14 @@ library(DBI)
           schema_table = 'birth.final_BLAH',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "The table specified by the data_params\\$schema_table argument does not exist."
-    )  
-    
+    )
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'sql_server',
@@ -787,18 +789,18 @@ library(DBI)
           schema_table = 'birth_final_analytic',
           time_var = 'chi_year',
           time_range = c(2021, 2022),
-          cols =c('chi_age'), 
+          cols =c('chi_age'),
           check_chi = FALSE
-        ), 
+        ),
         output_directory = myOutputFolder
-      ), 
+      ),
       "with a period between the schema and table"
-    )    
-    
-  })  
-  
+    )
+
+  })
+
   test_that("Specification of digits_mean argument", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -806,18 +808,18 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = NULL, 
-        digits_prop = 3, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = NULL,
+        digits_prop = 3,
+        abs_threshold = 3,
         rel_threshold = 2
-      ), 
+      ),
       "digits_mean must be a non-negative integer"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -825,18 +827,18 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = -1, 
-        digits_prop = 3, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = -1,
+        digits_prop = 3,
+        abs_threshold = 3,
         rel_threshold = 2
-      ), 
+      ),
       "digits_mean must be a non-negative integer"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -844,21 +846,21 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = "0", 
-        digits_prop = 3, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = "0",
+        digits_prop = 3,
+        abs_threshold = 3,
         rel_threshold = 2
-      ), 
+      ),
       "digits_mean must be a non-negative integer"
     )
-  })  
-  
+  })
+
   test_that("Specification of digits_prop argument", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -866,18 +868,18 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = NULL, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = NULL,
+        abs_threshold = 3,
         rel_threshold = 2
-      ), 
+      ),
       "digits_prop must be a non-negative integer"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -885,18 +887,18 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = NULL, 
-        abs_threshold = -3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = NULL,
+        abs_threshold = -3,
         rel_threshold = 2
-      ), 
+      ),
       "digits_prop must be a non-negative integer"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -904,21 +906,21 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = '3', 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = '3',
+        abs_threshold = 3,
         rel_threshold = 2
-      ), 
+      ),
       "digits_prop must be a non-negative integer"
     )
   })
-    
+
   test_that("Specification of abs_threshold argument", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -926,34 +928,15 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = NULL, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = NULL,
         rel_threshold = 2
-      ), 
-      "abs_threshold must be a non-negative number \\[0, 100\\]"
-    )
-    
-    expect_error(
-      test <- etl_qa_run_pipeline(
-        data_source_type = 'r_dataframe',
-        data_params = list(
-          data = synthetic_data,
-          time_var = 'myyear',
-          time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
-          check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = -2, 
-        rel_threshold = 2
-      ), 
+      ),
       "abs_threshold must be a non-negative number \\[0, 100\\]"
     )
 
@@ -964,15 +947,15 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = '2', 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = -2,
         rel_threshold = 2
-      ), 
+      ),
       "abs_threshold must be a non-negative number \\[0, 100\\]"
     )
 
@@ -983,21 +966,40 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = 120, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = '2',
         rel_threshold = 2
-      ), 
+      ),
+      "abs_threshold must be a non-negative number \\[0, 100\\]"
+    )
+
+    expect_error(
+      test <- etl_qa_run_pipeline(
+        data_source_type = 'r_dataframe',
+        data_params = list(
+          data = synthetic_data,
+          time_var = 'myyear',
+          time_range = c(2011, 2020),
+          cols = c('mycategorical', 'myinteger'),
+          check_chi = FALSE
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = 120,
+        rel_threshold = 2
+      ),
       "abs_threshold must be a non-negative number \\[0, 100\\]"
     )
   })
-  
+
   test_that("Specification of rel_threshold argument", {
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -1005,18 +1007,18 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = 3,
         rel_threshold = NULL
-      ), 
+      ),
       "rel_threshold must be a non-negative number \\[0, 100\\]"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -1024,18 +1026,18 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = 3,
         rel_threshold = -2
-      ), 
+      ),
       "rel_threshold must be a non-negative number \\[0, 100\\]"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -1043,18 +1045,18 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = 3,
         rel_threshold = '2'
-      ), 
+      ),
       "rel_threshold must be a non-negative number \\[0, 100\\]"
     )
-    
+
     expect_error(
       test <- etl_qa_run_pipeline(
         data_source_type = 'r_dataframe',
@@ -1062,21 +1064,20 @@ library(DBI)
           data = synthetic_data,
           time_var = 'myyear',
           time_range = c(2011, 2020),
-          cols = c('mycategorical', 'myinteger'), 
+          cols = c('mycategorical', 'myinteger'),
           check_chi = FALSE
-        ), 
-        output_directory = myOutputFolder, 
-        digits_mean = 0, 
-        digits_prop = 3, 
-        abs_threshold = 3, 
+        ),
+        output_directory = myOutputFolder,
+        digits_mean = 0,
+        digits_prop = 3,
+        abs_threshold = 3,
         rel_threshold = 120
-      ), 
+      ),
       "rel_threshold must be a non-negative number \\[0, 100\\]"
     )
-    
-  })  
-  
+
+  })
+
 # test `default_value` (`%||%`) ----
-  expect_equal(10L %||% 100, 10L) 
-  expect_equal(NULL %||% 100, 100) 
-  
+  expect_equal(10L %||% 100, 10L)
+  expect_equal(NULL %||% 100, 100)


### PR DESCRIPTION
- bump to 1.01.3
- Graphs of values now appropriately skip years with no data (important for questions or surveys that are not yearly)
- Improved graphs visually: color blind safe palette, use all solid lines, add layer of geom_point to see where the data actually is
- Replaced calls to some deprecated functions with new replacement functions
- Fixed global issues identified by devtools::check() (e.g., `setnames()` >> `data.table::setnames()`
- Fix #16 ... removed hard coding of chi_year as the time_var
- Updated tests to address changes above
- Passed all tests (including `tests/manual/test-etl_qa_run_pipeline.R`